### PR TITLE
Add README examples and document API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.*.swp
 *.gem
 *.rbc
 /.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.5
+- 2.1.5
+env:
+  global:
+    secure: TJZybuWikuUJi4lWN2vPclKbcKp4FhDwoY8wDPQvJaUw60+q3oSo6INsc3ym4VGzOlJ8gczc/BSXMefLF6TFrluqUQhMG6HYHC9d3wPcas2eHq8VQ840JxKMo7+aXBXdC6ZeoCJE2auKKkgASSxa7HZjg60OjMuYTZuMzf+H9IY=

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    minitest (5.5.0)
     rake (10.4.2)
 
 PLATFORMS
@@ -13,4 +14,5 @@ PLATFORMS
 
 DEPENDENCIES
   hash-joiner!
+  minitest
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    codeclimate-test-reporter (0.4.4)
+      simplecov (>= 0.7.1, < 1.0.0)
+    docile (1.1.5)
     minitest (5.5.0)
+    multi_json (1.10.1)
     rake (10.4.2)
+    simplecov (0.9.1)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  codeclimate-test-reporter
   hash-joiner!
   minitest
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    rake (10.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   hash-joiner!
+  rake

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Performs pruning or one-level promotion of `Hash` attributes (typically labeled `private:`), and deep merges and joins of `Hash` objects. Works on `Array` objects containing `Hash` objects as well.
 
-Downloads and API docs are available on the [hash-joiner RubyGems page](https://rubygems.org/gems/hash-joiner).
+Downloads and API docs are available on the [hash-joiner RubyGems page](https://rubygems.org/gems/hash-joiner). API documentation is written using [YARD markup](http://yardoc.org/).
+
+Contributed by the 18F team, part of the United States General Services Administration: https://18f.gsa.gov/
 
 ### Motivation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This gem was extracted from [the 18F Hub Joiner plugin](https://github.com/18F/h
 
 The typical use case is to have a YAML file containing both public and private data, with all private data nested within `private:` properties:
 
-```
+```ruby
 > require 'hash-joiner'
 > my_data_collection = {
     'name' => 'mbland', 'full_name' => 'Mike Bland',
@@ -28,7 +28,7 @@ The following examples, except for **Join an Array of Hash values**, all begin w
 
 #### Strip private data
 
-```
+```ruby
 > HashJoiner.remove_data my_data_collection, "private"
 => {"name"=>"mbland", "full_name"=>"Mike Bland"}
 ```
@@ -37,7 +37,7 @@ The following examples, except for **Join an Array of Hash values**, all begin w
 
 This will render `private:` data at the same level as other, nonprivate data:
 
-```
+```ruby
 > HashJoiner.promote_data my_data_collection, "private"
 => {"name"=>"mbland", "full_name"=>"Mike Bland",
     "email"=>"michael.bland@gsa.gov", "location"=>"DCA"}
@@ -45,7 +45,7 @@ This will render `private:` data at the same level as other, nonprivate data:
 
 #### Perform a deep merge with other Hash values
 
-```
+```ruby
 > extra_info = {
   'languages' => ['C++', 'Python'], 'full_name' => 'Michael S. Bland',
   'private' => {
@@ -79,7 +79,7 @@ This will render `private:` data at the same level as other, nonprivate data:
 
 This corresponds to the process of joining different collections of Jekyll-imported data within the 18F Hub, such as joining `site.data['private']['team']` into `site.data['team']`.
 
-```
+```ruby
 > class DummySite
     attr_accessor :data
     def initialize

--- a/README.md
+++ b/README.md
@@ -1,21 +1,118 @@
 ## hash-joiner Gem
 
-Performs pruning or one-level promotion of `Hash` attributes (typically labeled `"private"`) and deep joins of `Hash` objects. Works on `Array` objects containing `Hash` objects as well.
+Performs pruning or one-level promotion of `Hash` attributes (typically labeled `private:`), and deep merges and joins of `Hash` objects. Works on `Array` objects containing `Hash` objects as well.
 
-The typical use case is to have a YAML file containing both public and private data, with all private data nested within "private" properties:
+Downloads and API docs are available on the [hash-joiner RubyGems page](https://rubygems.org/gems/hash-joiner).
+
+### Motivation
+
+This gem was extracted from [the 18F Hub Joiner plugin](https://github.com/18F/hub/blob/master/_plugins/joiner.rb). That plugin manipulates [Jekyll-imported data](http://jekyllrb.com/docs/datafiles/) by removing or promoting private data, building indices, and performing joins between different data files so that the results appear as unified collections in Jekyll's `site.data` object. It serves as the first stage in a pipeline that also builds cross-references and canonicalizes data before generating static HTML pages and other artifacts.
+
+### Usage
+
+The typical use case is to have a YAML file containing both public and private data, with all private data nested within `private:` properties:
 
 ```
-my_data_collection = {
-  'name' => 'mbland', 'full_name' => 'Mike Bland',
+> require 'hash-joiner'
+> my_data_collection = {
+    'name' => 'mbland', 'full_name' => 'Mike Bland',
+    'private' => {
+      'email' => 'michael.bland@gsa.gov', 'location' => 'DCA',
+    },
+  }
+```
+
+The following examples, except for **Join an Array of Hash values**, all begin with `my_data_collection` in the above state.  Further examples can be found in the [test/](test/) directory.
+
+#### Strip private data
+
+```
+> HashJoiner.remove_data my_data_collection, "private"
+=> {"name"=>"mbland", "full_name"=>"Mike Bland"}
+```
+
+#### Promote private data
+
+This will render `private:` data at the same level as other, nonprivate data:
+
+```
+> HashJoiner.promote_data my_data_collection, "private"
+=> {"name"=>"mbland", "full_name"=>"Mike Bland",
+    "email"=>"michael.bland@gsa.gov", "location"=>"DCA"}
+```
+
+#### Perform a deep merge with other Hash values
+
+```
+> extra_info = {
+  'languages' => ['C++', 'Python'], 'full_name' => 'Michael S. Bland',
   'private' => {
-    'email' => 'michael.bland@gsa.gov', 'location' => 'DCA',
-   },
-}
+    'location' => 'Alexandria, VA', 'previous_companies' => ['Google'],
+    },
+  }
+
+> HashJoiner.deep_merge my_data_collection, extra_info
+=> {"name"=>"mbland", "full_name"=>"Michael S. Bland",
+    "private"=>{
+      "email"=>"michael.bland@gsa.gov", "location"=>"Alexandria, VA",
+      "previous_companies"=>["Google"]},
+    "languages"=>["C++", "Python"]}
+
+> extra_info = {
+    'languages' => ['Ruby'],
+    'private' => {
+      'previous_companies' => ['Northrop Grumman'],
+    },
+  }
+
+> HashJoiner.deep_merge my_data_collection, extra_info
+=> {"name"=>"mbland", "full_name"=>"Michael S. Bland",
+    "private"=>{
+      "email"=>"michael.bland@gsa.gov", "location"=>"Alexandria, VA",
+      "previous_companies"=>["Google", "Northrop Grumman"]},
+    "languages"=>["C++", "Python", "Ruby"]}
+```
+
+#### Join an Array of Hash values
+
+This corresponds to the process of joining different collections of Jekyll-imported data within the 18F Hub, such as joining `site.data['private']['team']` into `site.data['team']`.
+
+```
+> class DummySite
+    attr_accessor :data
+    def initialize
+      @data = {'private' => {}}
+    end
+  end
+
+> site = DummySite.new
+
+> site.data['team'] = [
+    {'name' => 'mbland', 'languages' => ['C++']},
+    {'name' => 'foobar', 'full_name' => 'Foo Bar'},
+  ]
+
+> site.data['private']['team'] = [
+    {'name' => 'mbland', 'languages' => ['Python', 'Ruby']},
+    {'name' => 'foobar', 'email' => 'foo.bar@gsa.gov'},
+    {'name' => 'bazquux', 'email' => 'baz.quux@gsa.gov'},
+  ]
+
+> HashJoiner.join_data 'team', 'name', site.data, site.data['private']
+=> {"private"=>{
+      "team"=>[
+        {"name"=>"mbland", "languages"=>["Python", "Ruby"]},
+        {"name"=>"foobar", "email"=>"foo.bar@gsa.gov"},
+        {"name"=>"bazquux", "email"=>"baz.quux@gsa.gov"}]},
+    "team"=>[
+      {"name"=>"mbland", "languages"=>["C++", "Python", "Ruby"]},
+      {"name"=>"foobar", "full_name"=>"Foo Bar", "email"=>"foo.bar@gsa.gov"},
+      {"name"=>"bazquux", "email"=>"baz.quux@gsa.gov"}]}
 ```
 
 ### Contributing
 
-Just fork [18F/hash-joiner](https://github.com/18F/hash-joiner) and start sending pull requests! Feel free to ping @mbland with any questions you may have, especially if the current documentation should've addressed your needs, but didn't.
+Just fork [18F/hash-joiner](https://github.com/18F/hash-joiner) and start sending pull requests! Feel free to ping [@mbland](https://github.com/mbland) with any questions you may have, especially if the current documentation should've addressed your needs, but didn't.
 
 ### Public domain
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## hash-joiner Gem
 
+[![Gem Version](https://badge.fury.io/rb/hash-joiner.svg)](http://badge.fury.io/rb/hash-joiner)
+[![Build Status](https://travis-ci.org/18F/hash-joiner.svg?branch=doc-update)](https://travis-ci.org/18F/hash-joiner)
+[![Code Climate](https://codeclimate.com/github/18F/hash-joiner/badges/gpa.svg)](https://codeclimate.com/github/18F/hash-joiner)
+
 Performs pruning or one-level promotion of `Hash` attributes (typically labeled `private:`), and deep merges and joins of `Hash` objects. Works on `Array` objects containing `Hash` objects as well.
 
 Downloads and API docs are available on the [hash-joiner RubyGems page](https://rubygems.org/gems/hash-joiner). API documentation is written using [YARD markup](http://yardoc.org/).
@@ -11,8 +15,6 @@ Contributed by the 18F team, part of the United States General Services Administ
 This gem was extracted from [the 18F Hub Joiner plugin](https://github.com/18F/hub/blob/master/_plugins/joiner.rb). That plugin manipulates [Jekyll-imported data](http://jekyllrb.com/docs/datafiles/) by removing or promoting private data, building indices, and performing joins between different data files so that the results appear as unified collections in Jekyll's `site.data` object. It serves as the first stage in a pipeline that also builds cross-references and canonicalizes data before generating static HTML pages and other artifacts.
 
 ### Installation
-
-The latest version is: [![Gem Version](https://badge.fury.io/rb/hash-joiner.svg)](http://badge.fury.io/rb/hash-joiner)
 
 ```
 $ gem install hash-joiner

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Contributed by the 18F team, part of the United States General Services Administ
 
 This gem was extracted from [the 18F Hub Joiner plugin](https://github.com/18F/hub/blob/master/_plugins/joiner.rb). That plugin manipulates [Jekyll-imported data](http://jekyllrb.com/docs/datafiles/) by removing or promoting private data, building indices, and performing joins between different data files so that the results appear as unified collections in Jekyll's `site.data` object. It serves as the first stage in a pipeline that also builds cross-references and canonicalizes data before generating static HTML pages and other artifacts.
 
+### Installation
+
+The latest version is: [![Gem Version](https://badge.fury.io/rb/hash-joiner.svg)](http://badge.fury.io/rb/hash-joiner)
+
+```
+$ gem install hash-joiner
+```
+
 ### Usage
 
 The typical use case is to have a YAML file containing both public and private data, with all private data nested within `private:` properties:
@@ -29,6 +37,7 @@ The following examples, except for **Join an Array of Hash values**, all begin w
 #### Strip private data
 
 ```ruby
+# Everything within the `private:` property will be deleted.
 > HashJoiner.remove_data my_data_collection, "private"
 => {"name"=>"mbland", "full_name"=>"Mike Bland"}
 ```
@@ -38,6 +47,8 @@ The following examples, except for **Join an Array of Hash values**, all begin w
 This will render `private:` data at the same level as other, nonprivate data:
 
 ```ruby
+# Everything within the `private:` property will be
+# promoted up one level.
 > HashJoiner.promote_data my_data_collection, "private"
 => {"name"=>"mbland", "full_name"=>"Mike Bland",
     "email"=>"michael.bland@gsa.gov", "location"=>"DCA"}
@@ -53,6 +64,8 @@ This will render `private:` data at the same level as other, nonprivate data:
     },
   }
 
+# The original Hash will have information added for
+# `full_name`, `languages', and `private => location`.
 > HashJoiner.deep_merge my_data_collection, extra_info
 => {"name"=>"mbland", "full_name"=>"Michael S. Bland",
     "private"=>{
@@ -67,6 +80,8 @@ This will render `private:` data at the same level as other, nonprivate data:
     },
   }
 
+# The Hash will now have added information for
+# `languages` and `private => previous_companies`.
 > HashJoiner.deep_merge my_data_collection, extra_info
 => {"name"=>"mbland", "full_name"=>"Michael S. Bland",
     "private"=>{
@@ -80,6 +95,7 @@ This will render `private:` data at the same level as other, nonprivate data:
 This corresponds to the process of joining different collections of Jekyll-imported data within the 18F Hub, such as joining `site.data['private']['team']` into `site.data['team']`.
 
 ```ruby
+# This defines a fake object emulating a Jekyll::Site.
 > class DummySite
     attr_accessor :data
     def initialize
@@ -89,17 +105,26 @@ This corresponds to the process of joining different collections of Jekyll-impor
 
 > site = DummySite.new
 
+# This data would correspond to _data/team.yml
+# in a Jekyll project.
 > site.data['team'] = [
     {'name' => 'mbland', 'languages' => ['C++']},
     {'name' => 'foobar', 'full_name' => 'Foo Bar'},
   ]
 
+# This data would correspond to _data/private/team.yml
+# in a Jekyll project.
 > site.data['private']['team'] = [
     {'name' => 'mbland', 'languages' => ['Python', 'Ruby']},
     {'name' => 'foobar', 'email' => 'foo.bar@gsa.gov'},
     {'name' => 'bazquux', 'email' => 'baz.quux@gsa.gov'},
   ]
 
+# After joining, each element of `site.data['team']` contains
+# the union of the original element and the corresponding
+# element in `site.data['private']['team']`.
+#
+# `site.data['private']` can now be safely discarded.
 > HashJoiner.join_data 'team', 'name', site.data, site.data['private']
 => {"private"=>{
       "team"=>[

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/hash-joiner.svg)](http://badge.fury.io/rb/hash-joiner)
 [![Build Status](https://travis-ci.org/18F/hash-joiner.svg?branch=doc-update)](https://travis-ci.org/18F/hash-joiner)
 [![Code Climate](https://codeclimate.com/github/18F/hash-joiner/badges/gpa.svg)](https://codeclimate.com/github/18F/hash-joiner)
+[![Test Coverage](https://codeclimate.com/github/18F/hash-joiner/badges/coverage.svg)](https://codeclimate.com/github/18F/hash-joiner)
 
 Performs pruning or one-level promotion of `Hash` attributes (typically labeled `private:`), and deep merges and joins of `Hash` objects. Works on `Array` objects containing `Hash` objects as well.
 

--- a/hash-joiner.gemspec
+++ b/hash-joiner.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
   s.files = ['lib/hash-joiner.rb', 'README.md']
   s.homepage = 'https://github.com/18F/hash-joiner'
   s.license = 'CC0'
+  s.add_development_dependency 'rake'
 end

--- a/hash-joiner.gemspec
+++ b/hash-joiner.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/18F/hash-joiner'
   s.license = 'CC0'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'minitest'
 end

--- a/hash-joiner.gemspec
+++ b/hash-joiner.gemspec
@@ -2,14 +2,15 @@ Gem::Specification.new do |s|
   s.name = 'hash-joiner'
   s.version = '0.0.0'
   s.date = '2014-12-19'
-  s.summary = 'Module for pruning, promoting, and deep-merging Hash data'
+  s.summary = (
+    'Module for pruning, promoting, deep-merging, and joining Hash data')
   s.description = (
     'Performs pruning or one-level promotion of Hash attributes (typically ' +
-    'labeled "private") and deep joins of Hash objects. Works on Array ' +
-    'objects containing Hash objects as well.')
+    'labeled "private:"), and deep merges and joins of Hash objects. Works ' +
+    'on Array objects containing Hash objects as well.')
   s.authors = ['Mike Bland']
   s.email = 'michael.bland@gsa.gov'
-  s.files = ['lib/hash-joiner.rb']
+  s.files = ['lib/hash-joiner.rb', 'README.md']
   s.homepage = 'https://github.com/18F/hash-joiner'
   s.license = 'CC0'
 end

--- a/hash-joiner.gemspec
+++ b/hash-joiner.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.license = 'CC0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/lib/hash-joiner.rb
+++ b/lib/hash-joiner.rb
@@ -176,6 +176,8 @@ module HashJoiner
       lhs_index[i[key_field]] = i
     end
 
+    # TODO(mbland): Make exception-safe by splitting into two loops: one for
+    # the assert; one to modify lhs after all the assertions have succeeded.
     rhs.each do |i|
       self.assert_is_hash_with_key(i, key_field, "RHS element")
       key = i[key_field]
@@ -185,5 +187,6 @@ module HashJoiner
         lhs << i
       end
     end
+    lhs
   end
 end

--- a/lib/hash-joiner.rb
+++ b/lib/hash-joiner.rb
@@ -131,7 +131,7 @@ module HashJoiner
   # +rhs+:: joined data source of type Hash (right-hand side)
   def self.join_data(category, key_field, lhs, rhs)
     rhs_data = rhs[category]
-    return unless rhs_data
+    return lhs unless rhs_data
 
     lhs_data = lhs[category]
     if !(lhs_data and [::Hash, ::Array].include? lhs_data.class)
@@ -141,6 +141,7 @@ module HashJoiner
     else
       self.join_array_data key_field, lhs_data, rhs_data
     end
+    lhs
   end
 
   # Raises JoinError if +h+ is not a Hash, or if

--- a/lib/hash-joiner.rb
+++ b/lib/hash-joiner.rb
@@ -1,32 +1,13 @@
-# Performs pruning or one-level promotion of Hash attributes (typically
-# labeled "private") and deep joins of Hash objects. Works on Array objects
-# containing Hash objects as well.
-#
-# The typical use case is to have a YAML file containing both public and
-# private data, with all private data nested within "private" properties:
-#
-# my_data_collection = {
-#   'name' => 'mbland', 'full_name' => 'Mike Bland',
-#   'private' => {
-#     'email' => 'michael.bland@gsa.gov', 'location' => 'DCA',
-#    },
-# }
-#
-# Contributed by the 18F team, part of the United States
-# General Services Administration: https://18f.gsa.gov/
-#
-# Author: Mike Bland (michael.bland@gsa.gov)
+# @author: Mike Bland (michael.bland@gsa.gov)
 module HashJoiner
   # Recursively strips information from +collection+ matching +key+.
   #
-  # To strip all private data from the example collection in the module
-  # comment:
-  #   HashJoiner.remove_data my_data_collection, "private"
-  # resulting in:
-  #   {'name' => 'mbland', 'full_name' => 'Mike Bland'}
-  #
-  # +collection+:: Hash or Array from which to strip information
-  # +key+:: key determining data to be stripped from +collection+
+  # @param collection [Hash,Array<Hash>] collection from which to strip
+  #   information
+  # @param key [String] property to be stripped from +collection+
+  # @return [Hash,Array<Hash>] +collection+ if +collection+ is a +Hash+ or
+  #   +Array<Hash>+
+  # @return [nil] if +collection+ is not a +Hash+ or +Array<Hash>+
   def self.remove_data(collection, key)
     if collection.instance_of? ::Hash
       collection.delete key
@@ -41,15 +22,12 @@ module HashJoiner
   # same level as +key+ itself. After promotion, each +key+ reference will
   # be deleted.
   #
-  # To promote private data within the example collection in the module
-  # comment, rendering it at the same level as other, nonprivate data:
-  #   HashJoiner.promote_data my_data_collection, "private" 
-  # resulting in:
-  #   {'name' => 'mbland', 'full_name' => 'Mike Bland',
-  #    'email' => 'michael.bland@gsa.gov', 'location' => 'DCA'}
-  #
-  # +collection+:: Hash or Array from which to promote information
-  # +key+:: key determining data to be promoted within +collection+
+  # @param collection [Hash,Array<Hash>] collection in which to promote
+  #   information
+  # @param key [String] property to be promoted within +collection+
+  # @return [Hash,Array<Hash>] +collection+ if +collection+ is a +Hash+ or
+  #   +Array<Hash>+
+  # @return [nil] if +collection+ is not a +Hash+ or +Array<Hash>+
   def self.promote_data(collection, key)
     if collection.instance_of? ::Hash
       if collection.member? key
@@ -76,20 +54,21 @@ module HashJoiner
     end
   end
 
-  # Raised by deep_merge() if lhs and rhs are of different types.
+  # Raised by +deep_merge+ if +lhs+ and +rhs+ are of different types.
+  # @see deep_merge
   class MergeError < ::Exception
   end
 
-  # Performs a deep merge of Hash and Array structures. If the collections
-  # are Hashes, Hash or Array members of +rhs+ will be deep-merged with
-  # any existing members in +lhs+. If the collections are Arrays, the values
-  # from +rhs+ will be appended to lhs.
+  # Performs a deep merge of +Hash+ and +Array+ structures. If the collections
+  # are +Hash+es, +Hash+ or +Array+ members of +rhs+ will be deep-merged with
+  # any existing members in +lhs+. If the collections are +Array+s, the values
+  # from +rhs+ will be appended to +lhs+.
   #
-  # Raises MergeError if lhs and rhs are of different classes, or if they
-  # are of classes other than Hash or Array.
-  #
-  # +lhs+:: merged data sink (left-hand side)
-  # +rhs+:: merged data source (right-hand side)
+  # @param lhs [Hash,Array] merged data sink (left-hand side)
+  # @param rhs [Hash,Array] merged data source (right-hand side)
+  # @return [Hash,Array] +lhs+
+  # @raise [MergeError] if +lhs+ and +rhs+ are of different classes, or if
+  #   they are of classes other than Hash or Array.
   def self.deep_merge(lhs, rhs)
     mergeable_classes = [::Hash, ::Array]
 
@@ -115,20 +94,27 @@ module HashJoiner
     lhs
   end
 
-  # Raised by join_data() if an error is encountered.
+  # Raised by +join_data+ if an error is encountered.
+  # @see join_data
   class JoinError < ::Exception
   end
 
-  # Joins objects in +lhs[category]+ with data from +rhs[category]+. If the
-  # object collections are of type Array of Hash, key_field will be used as
-  # the primary key; otherwise key_field is ignored.
+  # Joins objects in +lhs+[category] with data from +rhs+[category]. If the
+  # +category+ objects are of type +Array<Hash>+, +key_field+ will be used as
+  # the primary key to join the objects in the two collections; otherwise
+  # +key_field+ is ignored.
   #
-  # Raises JoinError if an error is encountered.
-  #
-  # +category+:: determines member of +lhs+ to join with +rhs+
-  # +key_field+:: if specified, primary key for Array of joined objects
-  # +lhs+:: joined data sink of type Hash (left-hand side)
-  # +rhs+:: joined data source of type Hash (right-hand side)
+  # @param category [String] determines member of +lhs+ to join with +rhs+
+  # @param key_field [String] primary key for objects in each +Array<Hash>+
+  #   collection specified by +category+
+  # @param lhs [Hash,Array<Hash>] joined data sink of type Hash (left-hand
+  #   side)
+  # @param rhs [Hash,Array<Hash>] joined data source of type Hash (right-hand
+  #   side)
+  # @return [Hash,Array<Hash>] +lhs+
+  # @raise [JoinError] if an error is encountered
+  # @see deep_merge
+  # @see join_array_data
   def self.join_data(category, key_field, lhs, rhs)
     rhs_data = rhs[category]
     return lhs unless rhs_data
@@ -144,8 +130,14 @@ module HashJoiner
     lhs
   end
 
-  # Raises JoinError if +h+ is not a Hash, or if
-  # +key_field+ is absent from any element of +lhs+ or +rhs+.
+  # Asserts that +h+ is a hash containing +key+. Used to ensure that a +Hash+
+  # can be joined with another +Hash+ object.
+  #
+  # @raise [JoinError] if +h+ is not a +Hash+, or if +key_field+ is absent
+  #   from any element of +lhs+ or +rhs+.
+  # @return [NilClass] +nil+
+  # @see join_data
+  # @see join_array_data
   def self.assert_is_hash_with_key(h, key, error_prefix)
     if !h.instance_of? ::Hash
       raise JoinError.new("#{error_prefix} is not a Hash: #{h}")
@@ -154,17 +146,20 @@ module HashJoiner
     end
   end
 
-  # Joins data in the +lhs+ Array with data from the +rhs+ Array based on
-  # +key_field+. Both +lhs+ and +rhs+ should be of type Array of Hash.
-  # Performs a deep_merge on matching objects; assigns values from +rhs+ to
-  # +lhs+ if no corresponding object yet exists in lhs.
+  # Joins data in +lhs+ with data from +rhs+ based on +key_field+. Both +lhs+
+  # and +rhs+ should be of type +Array<Hash>+. Performs a +deep_merge+ on
+  # matching objects; assigns values from +rhs+ to +lhs+ if no corresponding
+  # value yet exists in +lhs+.
   #
-  # Raises JoinError if either lhs or rhs is not an Array of Hash, or if
-  # +key_field+ is absent from any element of +lhs+ or +rhs+.
-  #
-  # +key_field+:: primary key for joined objects
-  # +lhs+:: joined data sink (left-hand side)
-  # +rhs+:: joined data source (right-hand side)
+  # @param key_field [String] primary key for joined objects
+  # @param lhs [Array<Hash>] joined data sink (left-hand side)
+  # @param rhs [Array<Hash>] joined data source (right-hand side)
+  # @return [Array<Hash>] +lhs+
+  # @raise [JoinError] if either +lhs+ or +rhs+ is not an +Array<Hash>+, or if
+  #   +key_field+ is absent from any element of +lhs+ or +rhs+
+  # @see deep_merge
+  # @see join_data
+  # @see assert_is_hash_with_key
   def self.join_array_data(key_field, lhs, rhs)
     unless lhs.instance_of? ::Array and rhs.instance_of? ::Array
       raise JoinError.new("Both lhs (#{lhs.class}) and " +

--- a/lib/hash-joiner.rb
+++ b/lib/hash-joiner.rb
@@ -112,6 +112,7 @@ module HashJoiner
     elsif rhs.instance_of? ::Array
       lhs.concat rhs
     end
+    lhs
   end
 
   # Raised by join_data() if an error is encountered.

--- a/test/deep-merge-test.rb
+++ b/test/deep-merge-test.rb
@@ -1,5 +1,6 @@
+require_relative "../lib/hash-joiner"
+require_relative "test_helper"
 require "minitest/autorun"
-require "hash-joiner"
 
 module HashJoinerTest
   class DeepMergeTest < ::Minitest::Test

--- a/test/deep-merge-test.rb
+++ b/test/deep-merge-test.rb
@@ -18,28 +18,28 @@ module HashJoinerTest
     def test_merge_into_empty_hash
       lhs = {}
       rhs = {:foo => true}
-      HashJoiner.deep_merge lhs, rhs
+      assert_same lhs, HashJoiner.deep_merge(lhs, rhs)
       assert_equal rhs, lhs
     end
 
     def test_merge_into_empty_array
       lhs = []
       rhs = [{:foo => true}]
-      HashJoiner.deep_merge lhs, rhs
+      assert_same lhs, HashJoiner.deep_merge(lhs, rhs)
       assert_equal rhs, lhs
     end
 
     def test_rhs_hash_overwrites_nonmergeable_lhs_hash_values
       lhs = {:foo => false}
       rhs = {:foo => true}
-      HashJoiner.deep_merge lhs, rhs
+      assert_same lhs, HashJoiner.deep_merge(lhs, rhs)
       assert_equal rhs, lhs
     end
 
     def test_rhs_appends_values_to_lhs
       lhs = [{:foo => false}]
       rhs = [{:foo => true}]
-      HashJoiner.deep_merge lhs, rhs
+      assert_same lhs, HashJoiner.deep_merge(lhs, rhs)
       assert_equal [{:foo => false}, {:foo => true}], lhs
     end
 
@@ -62,7 +62,7 @@ module HashJoinerTest
           'les_pauls' => 1,
           },
         }
-      HashJoiner.deep_merge lhs, rhs
+      assert_same lhs, HashJoiner.deep_merge(lhs, rhs)
 
       expected = {
         'name' => 'mbland',

--- a/test/join-array-data-test.rb
+++ b/test/join-array-data-test.rb
@@ -4,7 +4,9 @@ require "hash-joiner"
 module HashJoinerTest
   class JoinArrayDataTest < ::Minitest::Test
     def test_empty_arrays
-      assert_empty HashJoiner.join_array_data('unused', [], [])
+      lhs = []
+      assert_same lhs, HashJoiner.join_array_data('unused', lhs, [])
+      assert_empty lhs
     end
 
     def test_assert_raises_if_lhs_and_rhs_are_not_arrays
@@ -34,14 +36,14 @@ module HashJoinerTest
     def test_leave_lhs_alone_if_rhs_is_empty
       lhs = [{'key'=>true}]
       rhs = []
-      HashJoiner.join_array_data('key', lhs, rhs)
+      assert_same lhs, HashJoiner.join_array_data('key', lhs, rhs)
       assert_equal [{'key'=>true}], lhs
     end
 
     def test_lhs_matches_rhs_if_lhs_is_empty
       lhs = []
       rhs = [{'key'=>true}]
-      HashJoiner.join_array_data('key', lhs, rhs)
+      assert_same lhs, HashJoiner.join_array_data('key', lhs, rhs)
       assert_equal [{'key'=>true}], lhs
     end
 
@@ -65,7 +67,7 @@ module HashJoinerTest
          'languages' => ['C++', 'Python', 'Ruby'],
         },
       ]
-      HashJoiner.join_array_data('name', lhs, rhs)
+      assert_same lhs, HashJoiner.join_array_data('name', lhs, rhs)
       assert_equal expected, lhs
     end
 
@@ -107,7 +109,7 @@ module HashJoinerTest
          'email' => 'baz.quux@gsa.gov',
         },
       ]
-      HashJoiner.join_array_data('name', lhs, rhs)
+      assert_same lhs, HashJoiner.join_array_data('name', lhs, rhs)
       assert_equal expected, lhs
     end
   end

--- a/test/join-array-data-test.rb
+++ b/test/join-array-data-test.rb
@@ -1,5 +1,6 @@
+require_relative "../lib/hash-joiner"
+require_relative "test_helper"
 require "minitest/autorun"
-require "hash-joiner"
 
 module HashJoinerTest
   class JoinArrayDataTest < ::Minitest::Test

--- a/test/join-data-test.rb
+++ b/test/join-data-test.rb
@@ -6,21 +6,21 @@ module HashJoinerTest
     def test_ignore_if_rhs_empty
       lhs = {'team' => [{'name' => 'mbland'}]}
       rhs = {}
-      HashJoiner.join_data 'team', 'name', lhs, rhs
+      assert_same lhs, HashJoiner.join_data('team', 'name', lhs, rhs)
       assert_equal({'team' => [{'name' => 'mbland'}]}, lhs)
     end
 
     def test_assign_value_if_lhs_empty
       lhs = {}
       rhs = {'team' => [{'name' => 'mbland'}]}
-      HashJoiner.join_data 'team', 'name', lhs, rhs
+      assert_same lhs, HashJoiner.join_data('team', 'name', lhs, rhs)
       assert_equal rhs, lhs
     end
 
     def test_overwrite_nonmergeable_values
       lhs = {'team' => 'mbland'}
       rhs = {'team' => 'foobar'}
-      HashJoiner.join_data 'team', 'name', lhs, rhs
+      assert_same lhs, HashJoiner.join_data('team', 'name', lhs, rhs)
       assert_equal rhs, lhs
     end
 
@@ -48,7 +48,7 @@ module HashJoinerTest
         },
       }
 
-      HashJoiner.join_data 'team', 'name', lhs, rhs
+      assert_same lhs, HashJoiner.join_data('team', 'name', lhs, rhs)
       assert_equal expected, lhs
     end
 
@@ -73,7 +73,7 @@ module HashJoinerTest
           {'name' => 'bazquux', 'email' => 'baz.quux@gsa.gov'},
         ],
       }
-      HashJoiner.join_data 'team', 'name', lhs, rhs
+      assert_same lhs, HashJoiner.join_data('team', 'name', lhs, rhs)
       assert_equal expected, lhs
     end
   end

--- a/test/join-data-test.rb
+++ b/test/join-data-test.rb
@@ -1,5 +1,6 @@
+require_relative "../lib/hash-joiner"
+require_relative "test_helper"
 require "minitest/autorun"
-require "hash-joiner"
 
 module HashJoinerTest
   class JoinDataTest < ::Minitest::Test

--- a/test/promote-data-test.rb
+++ b/test/promote-data-test.rb
@@ -1,5 +1,6 @@
+require_relative "../lib/hash-joiner"
+require_relative "test_helper"
 require "minitest/autorun"
-require "hash-joiner"
 
 module HashJoinerTest
   class PromoteDataTest < ::Minitest::Test

--- a/test/promote-data-test.rb
+++ b/test/promote-data-test.rb
@@ -12,11 +12,11 @@ module HashJoinerTest
 
     def test_no_effect_on_empty_collections
       hash_data = {}
-      HashJoiner.promote_data hash_data, 'private'
+      assert_same hash_data, HashJoiner.promote_data(hash_data, 'private')
       assert_empty hash_data
 
       array_data = []
-      HashJoiner.promote_data array_data, 'private'
+      assert_same array_data, HashJoiner.promote_data(array_data, 'private')
       assert_empty array_data
     end
 
@@ -33,7 +33,7 @@ module HashJoinerTest
         'full_name' => 'Mike Bland',
       }
 
-      HashJoiner.promote_data data, 'private'
+      assert_same data, HashJoiner.promote_data(data, 'private')
       assert_equal expected, data
     end
 
@@ -48,7 +48,7 @@ module HashJoinerTest
         {'name' => 'foobar'},
       ]
 
-      HashJoiner.promote_data data, 'private'
+      assert_same data, HashJoiner.promote_data(data, 'private')
       assert_equal expected, data
     end
 
@@ -84,7 +84,7 @@ module HashJoinerTest
         },
       ]
 
-      HashJoiner.promote_data data, 'private'
+      assert_same data, HashJoiner.promote_data(data, 'private')
       assert_equal expected, data
     end
 
@@ -118,7 +118,7 @@ module HashJoinerTest
         ],
       }
 
-      HashJoiner.promote_data data, 'private'
+      assert_same data, HashJoiner.promote_data(data, 'private')
       assert_equal expected, data
     end
   end

--- a/test/remove-data-test.rb
+++ b/test/remove-data-test.rb
@@ -1,5 +1,6 @@
+require_relative "../lib/hash-joiner"
+require_relative "test_helper"
 require "minitest/autorun"
-require "hash-joiner"
 
 module HashJoinerTest
   class RemoveDataTest < ::Minitest::Test

--- a/test/remove-data-test.rb
+++ b/test/remove-data-test.rb
@@ -11,30 +11,41 @@ module HashJoinerTest
     end
 
     def test_ignore_empty_collections
-      assert_equal({}, HashJoiner.remove_data({}, 'private'))
-      assert_equal([], HashJoiner.remove_data([], 'private'))
+      empty_hash = {}
+      assert_same empty_hash, HashJoiner.remove_data(empty_hash, 'private')
+      assert_empty empty_hash
+      empty_list = []
+      assert_same empty_list, HashJoiner.remove_data(empty_list, 'private')
+      assert_empty empty_list
     end
 
     def test_remove_top_level_private_data_from_hash
-      assert_equal({'name' => 'mbland', 'full_name' => 'Mike Bland'},
-        HashJoiner.remove_data(
-          {'name' => 'mbland', 'full_name' => 'Mike Bland',
-           'private' => {'email' => 'michael.bland@gsa.gov'}}, 'private'))
+      data = {
+        'name' => 'mbland', 'full_name' => 'Mike Bland',
+        'private' => {'email' => 'michael.bland@gsa.gov'}
+        }
+      assert_same data, HashJoiner.remove_data(data, 'private')
+      assert_equal({'name' => 'mbland', 'full_name' => 'Mike Bland'}, data)
     end
 
     def test_remove_top_level_private_data_from_array
-      assert_equal([{'name' => 'mbland', 'full_name' => 'Mike Bland'}],
-        HashJoiner.remove_data(
-          [{'name' => 'mbland', 'full_name' => 'Mike Bland'},
-           {'private' => {'name' => 'foobar'}}], 'private'))
+      data = [
+        {'name' => 'mbland', 'full_name' => 'Mike Bland'},
+        {'private' => {'name' => 'foobar'}}
+        ]
+      assert_same data, HashJoiner.remove_data(data, 'private')
+      assert_equal([{'name' => 'mbland', 'full_name' => 'Mike Bland'}], data)
     end
 
     def test_remove_private_data_from_object_array_at_different_depths
-      assert_equal([{'name' => 'mbland', 'full_name' => 'Mike Bland'}],
-        HashJoiner.remove_data(
-          [{'name' => 'mbland', 'full_name' => 'Mike Bland',
-            'private' => {'email' => 'michael.bland@gsa.gov'}},
-           {'private' => [{'name' => 'foobar'}]}], 'private'))
+      data = [
+        {'name' => 'mbland', 'full_name' => 'Mike Bland',
+         'private' => {'email' => 'michael.bland@gsa.gov'}
+        },
+        {'private' => [{'name' => 'foobar'}]}
+        ]
+      assert_same data, HashJoiner.remove_data(data, 'private')
+      assert_equal([{'name' => 'mbland', 'full_name' => 'Mike Bland'}], data)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start


### PR DESCRIPTION
This PR also contains a small code change (supported by tests) to ensure that +deep_merge+, +join_data+, and +join_array_data+ always return the +lhs+ object. On top of providing consistent, expected behavior, it also made creating and verifying the usage examples easier.

@adelevie Mind taking a look? Happy for feedback on whether the explanations are clear, and for YARD tips (or better doc tips in general) if you have them.