### PR TITLE
Functions for setting and pruning empty properties

### DIFF
--- a/lib/hash-joiner.rb
+++ b/lib/hash-joiner.rb
@@ -270,10 +270,9 @@ module HashJoiner
   def self.assign_empty_defaults(collection, array_properties, hash_properties,
     string_properties)
     if collection.instance_of? ::Hash
-      h = collection
-      array_properties.each {|i| h[i] = Array.new unless collection[i]}
-      hash_properties.each {|i| h[i] = Hash.new unless collection[i]}
-      string_properties.each {|i| h[i] = String.new unless collection[i]}
+      array_properties.each {|i| collection[i] ||= Array.new}
+      hash_properties.each {|i| collection[i] ||= Hash.new}
+      string_properties.each {|i| collection[i] ||= String.new}
     elsif collection.instance_of? ::Array
       collection.each do |i|
         assign_empty_defaults(i,

--- a/lib/hash-joiner.rb
+++ b/lib/hash-joiner.rb
@@ -257,4 +257,47 @@ module HashJoiner
     end
     lhs
   end
+
+  # Given a collection, initialize any missing properties to empty values.
+  # @param collection [Hash<String>,Array<Hash<String>>] collection to update
+  # @param array_properties [Array<String>] list of properties to initialize
+  #   with an empty Array
+  # @param hash_properties [Array<String>] list of properties to initialize
+  #   with an empty Hash
+  # @param string_properties [Array<String>] list of properties to initialize
+  #   with an empty String
+  # @return collection
+  def self.assign_empty_defaults(collection, array_properties, hash_properties,
+    string_properties)
+    if collection.instance_of? ::Hash
+      h = collection
+      array_properties.each {|i| h[i] = Array.new unless collection[i]}
+      hash_properties.each {|i| h[i] = Hash.new unless collection[i]}
+      string_properties.each {|i| h[i] = String.new unless collection[i]}
+    elsif collection.instance_of? ::Array
+      collection.each do |i|
+        assign_empty_defaults(i,
+          array_properties, hash_properties, string_properties)
+      end
+    end
+    collection
+  end
+
+  # Recursively prunes all empty properties from every element of a
+  # collection.
+  # @param collection [Hash<String>,Array<Hash<String>>] collection to update
+  # @param array_properties [Array<String>] list of properties to initialize
+  def self.prune_empty_properties(collection)
+    if collection.instance_of? ::Hash
+      collection.each_value {|i| prune_empty_properties i}
+      collection.delete_if do |unused_key, value|
+        (value.instance_of? ::Hash or value.instance_of? ::Array or
+         value.instance_of? ::String) and value.empty?
+      end
+    elsif collection.instance_of? ::Array
+      collection.each {|i| prune_empty_properties i}
+      collection.delete_if {|i| i.empty?}
+    end
+    collection
+  end
 end

--- a/test/assign-empty-defaults-test.rb
+++ b/test/assign-empty-defaults-test.rb
@@ -8,7 +8,7 @@ module HashJoinerTest
       assert_empty HashJoiner.assign_empty_defaults({}, [], [], [])
     end
 
-    def test_hash
+    def test_empty_hash
       assert_equal({'foo' => [], 'bar' => {}, 'baz' => ''},
         HashJoiner.assign_empty_defaults({}, ['foo'], ['bar'], ['baz']))
     end
@@ -18,9 +18,15 @@ module HashJoinerTest
       assert_equal([{}], HashJoiner.assign_empty_defaults([{}], [], [], []))
     end
 
-    def test_array
+    def test_empty_array
       assert_equal([{'foo' => [], 'bar' => {}, 'baz' => ''}],
         HashJoiner.assign_empty_defaults([{}], ['foo'], ['bar'], ['baz']))
+    end
+
+    def test_do_not_overwrite_existing_values
+      original = {'foo' => [1], 'bar' => {'k' => 2}, 'baz' => '3'}
+      assert_equal({'foo' => [1], 'bar' => {'k' => 2}, 'baz' => '3'},
+        HashJoiner.assign_empty_defaults(original, ['foo'], ['bar'], ['baz']))
     end
   end
 end

--- a/test/assign-empty-defaults-test.rb
+++ b/test/assign-empty-defaults-test.rb
@@ -1,0 +1,26 @@
+require_relative "../lib/hash-joiner"
+require_relative "test_helper"
+require "minitest/autorun"
+
+module HashJoinerTest
+  class AssignEmptyDefaultsTest < ::Minitest::Test
+    def test_hash_all_properties_empty
+      assert_empty HashJoiner.assign_empty_defaults({}, [], [], [])
+    end
+
+    def test_hash
+      assert_equal({'foo' => [], 'bar' => {}, 'baz' => ''},
+        HashJoiner.assign_empty_defaults({}, ['foo'], ['bar'], ['baz']))
+    end
+
+    def test_array_all_properties_empty
+      assert_empty HashJoiner.assign_empty_defaults([], [], [], [])
+      assert_equal([{}], HashJoiner.assign_empty_defaults([{}], [], [], []))
+    end
+
+    def test_array
+      assert_equal([{'foo' => [], 'bar' => {}, 'baz' => ''}],
+        HashJoiner.assign_empty_defaults([{}], ['foo'], ['bar'], ['baz']))
+    end
+  end
+end

--- a/test/prune-empty-properties-test.rb
+++ b/test/prune-empty-properties-test.rb
@@ -1,0 +1,40 @@
+require_relative "../lib/hash-joiner"
+require_relative "test_helper"
+require "minitest/autorun"
+
+module HashJoinerTest
+  class PruneEmptyPropertiesTest < ::Minitest::Test
+    def test_empty
+      assert_empty HashJoiner.prune_empty_properties({})
+      assert_empty HashJoiner.prune_empty_properties([])
+    end
+
+    def test_pruning
+      original = [
+        {'name' => 'mbland',
+         'full_name' => '',
+         'projects' => [],
+         'departments' => [{}],
+         'working_groups' => [
+           {'name' => 'Documentation',
+            'leads' => ['mbland'],
+            'members' => [],
+           },
+         ],
+        },
+      ]
+
+      expected = [
+        {'name' => 'mbland',
+         'working_groups' => [
+           {'name' => 'Documentation',
+            'leads' => ['mbland'],
+           },
+         ],
+        },
+      ]
+
+      assert_equal(expected, HashJoiner.prune_empty_properties(original))
+    end
+  end
+end


### PR DESCRIPTION
`assign_empty_defaults` intends to enable the simplification of logic that
currently depends on the `(collection[value] || [])` idiom to avoid `nil`
values.

`prune_empty_properties` intends to undo this by replacing empty values with
`nil`. In the Liquid templates used by Jekyll, this enables the use of
expressions such as `{% if collection.value %}` rather than
`{% if collection.value != empty %}` or
`{% if collection.value.size != 0 %}`.

cc: @afeld @adelevie 