### PR TITLE
prune_empty_properties: avoid infinite recursion

### DIFF
--- a/test/prune-empty-properties-test.rb
+++ b/test/prune-empty-properties-test.rb
@@ -36,5 +36,42 @@ module HashJoinerTest
 
       assert_equal(expected, HashJoiner.prune_empty_properties(original))
     end
+
+    def test_pruning_circular_reference
+      team_member = {
+        'name' => 'mbland',
+        'full_name' => '',
+        'projects' => [],
+        'departments' => [{}],
+        'working_groups' => [],
+        }
+      working_group = {
+        'name' => 'Documentation',
+        'leads' => [],
+        'members' => [],
+        'artifacts' => [],
+        'repositories' => [{}],
+        'mission' => '',
+      }
+
+      team_member['working_groups'] << working_group
+      working_group['leads'] << team_member
+      working_group['members'] << team_member
+
+      original = [team_member, working_group]
+
+      expected = [
+        {'name' => 'mbland',
+         'working_groups' => [working_group],
+        },
+        {'name' => 'Documentation',
+         'leads' => [team_member],
+         'members' => [team_member],
+        },
+      ]
+      actual = HashJoiner.prune_empty_properties original
+      assert_equal(expected[0].keys, actual[0].keys)
+      assert_equal(expected[1].keys, actual[1].keys)
+    end
   end
 end


### PR DESCRIPTION
Without this change, collections of objects containing circular references will cause infinite recursion.

cc: @afeld @adelevie